### PR TITLE
check both HTTP and HTTPS when searching IA for wiki dumps

### DIFF
--- a/wikiteam3/dumpgenerator/api/api.py
+++ b/wikiteam3/dumpgenerator/api/api.py
@@ -11,7 +11,6 @@ from wikiteam3.utils import get_random_UserAgent
 
 def check_API(api: str, session: requests.Session):
     """Checking API availability"""
-    global cj
     # handle redirects
     r: Optional[requests.Response] = None
     for i in range(4):

--- a/wikiteam3/utils/ia_checker.py
+++ b/wikiteam3/utils/ia_checker.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 from typing import List, Optional
+from urllib.parse import urlparse
 
 from internetarchive import ArchiveSession, Search
 
@@ -32,7 +33,13 @@ def search_ia(apiurl: Optional[str] = None, indexurl: Optional[str] = None, adde
 
     ia_session = ArchiveSession()
 
-    query = f'(originalurl:"{apiurl}" OR originalurl:"{indexurl}")'
+    urls_to_check: List[str] = [
+        urlparse(url)._replace(scheme=scheme).geturl()
+        for url in (apiurl, indexurl) if url
+        for scheme in ('http', 'https')
+    ]
+
+    query = '(' + ' OR '.join([f'originalurl:"{url}"' for url in urls_to_check]) + ')'
     if addeddate_intervals:
         query += f' AND addeddate:[{addeddate_intervals[0]} TO {addeddate_intervals[1]}]'
     search = Search(ia_session, query=query,


### PR DESCRIPTION
It's possible for wikis that don't redirect HTTP to HTTPS to be archived on either protocol, which might create duplication of the same wiki on IA. This checks both against IA to prevent duplication if that happens.