### PR TITLE
Fix link to IRC channel on hackint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pip install wikiteam3 --upgrade
 >
 > Even more, we also accept DokuWiki and PukiWiki archive requests.
 > 
-> - wikiteam IRC (webirc): https://webirc.hackint.org/#irc://irc.hackint.org/wikiteam
+> - wikiteam IRC (webirc): https://chat.hackint.org/?join=#wikiteam
 > - wikiteam IRC logs: https://irclogs.archivete.am/wikiteam
 
 ## Dumpgenerator usage


### PR DESCRIPTION
hackint switched from KiwiIRC (webirc.hackint.org) to using The Lounge (chat.hackint.org). Thus URLs need to be adapted to the new format to be able to predefine channels to join.