### PR TITLE
fix: Incomplete redirect dump

### DIFF
--- a/wikiteam3/dumpgenerator/dump/redirect/allredirects.py
+++ b/wikiteam3/dumpgenerator/dump/redirect/allredirects.py
@@ -43,6 +43,7 @@ def get_redirects_by_allredirects(config: Config, session: requests.Session):
                 print(f"  arcontinue={ar_params[continueKey]}")
             else:
                 # End of continuation. We are done with this namespace.
+                ar_params['arcontinue'] = None # Don't pass arcontinue at all
                 break
 
 # TODO: unit test

--- a/wikiteam3/dumpgenerator/dump/redirect/allredirects.py
+++ b/wikiteam3/dumpgenerator/dump/redirect/allredirects.py
@@ -7,6 +7,7 @@ from wikiteam3.dumpgenerator.config import Config
 from wikiteam3.utils.util import ALL_NAMESPACE_FLAG
 
 def get_redirects_by_allredirects(config: Config, session: requests.Session):
+    continueKey = 'arcontinue'
     assert config.api, "API URL is required"
 
     namespaces, namespacenames = getNamespacesAPI(config=config, session=session)
@@ -20,6 +21,8 @@ def get_redirects_by_allredirects(config: Config, session: requests.Session):
         "continue": "" # DEV.md#Continuation
     }
     for ns in namespaces:
+        if continueKey in ar_params:
+            del ar_params[continueKey] # reset continue parameter
         if ALL_NAMESPACE_FLAG not in config.namespaces: # user has specified namespaces
             if ns not in config.namespaces:
                 print(f"Skipping namespace {ns}")
@@ -37,13 +40,11 @@ def get_redirects_by_allredirects(config: Config, session: requests.Session):
                 yield redirect
 
             if "continue" in allredirects_response:
-                continueKey = 'arcontinue'
                 # update continue parameter
                 ar_params[continueKey] = allredirects_response["continue"][continueKey]
-                print(f"  arcontinue={ar_params[continueKey]}")
+                print(f"  {continueKey}={ar_params[continueKey]}")
             else:
                 # End of continuation. We are done with this namespace.
-                ar_params['arcontinue'] = None # Don't pass arcontinue at all
                 break
 
 # TODO: unit test


### PR DESCRIPTION
There is a bug that causes incomplete redirect dumps: When moving on to the next namespace, the `arcontinue` parameter is not cleared. This pull request fixes this.