### PR TITLE
fix: `read_titles()` no longer returns `--END--` at last iteration

### DIFF
--- a/wikiteam3/dumpgenerator/api/page_titles.py
+++ b/wikiteam3/dumpgenerator/api/page_titles.py
@@ -273,13 +273,20 @@ def read_titles(config: Config, session: requests.Session, start: Optional[str]=
     """ If True, we are looking for the `start` title to start reading from """
     end_reached = False
     with open(f"{config.path}/{titles_filename}", encoding="utf-8") as f:
-        for line in f:
-            title = line.strip()
+        it = iter(f)
+        line = next(it, None)
+        next_line = next(it, None)
+        while True:
+            title = line.strip() # Strip trailing '\n'
+                                 # TODO: Can title begins or ends with whitespaces? (https://docs.python.org/3/library/string.html#string.whitespace)
 
-            if title == "--END--":
-                end_reached = True
-            else:
-                end_reached = False
+            if next_line is None:
+                # TODO: Use global variable instead of hardcoding
+                # TODO: '--END--' is a valid title, change it to something invalid
+                if title == '--END--':
+                    break
+                else:
+                    raise EOFError("End of file flag `--END--` not found in the last line")
 
             if seeking and title != start:
                 continue
@@ -287,6 +294,4 @@ def read_titles(config: Config, session: requests.Session, start: Optional[str]=
                 seeking = False
 
             yield title
-
-    if not end_reached:
-        raise EOFError("End of file flag `--END--` not found in the last line")
+            line, next_line = next_line, next(it, None)

--- a/wikiteam3/dumpgenerator/api/page_titles.py
+++ b/wikiteam3/dumpgenerator/api/page_titles.py
@@ -289,10 +289,9 @@ def read_titles(config: Config, session: requests.Session, start: Optional[str]=
                 else:
                     raise EOFError("End of file flag `--END--` not found in the last line")
 
-            if seeking and title != start:
-                continue
-            else:
+            if seeking and title == start:
                 seeking = False
+            if not seeking:
+                yield title
 
-            yield title
             line, next_line = next_line, next(it, None)

--- a/wikiteam3/dumpgenerator/api/page_titles.py
+++ b/wikiteam3/dumpgenerator/api/page_titles.py
@@ -271,14 +271,15 @@ def read_titles(config: Config, session: requests.Session, start: Optional[str]=
 
     seeking = start is not None
     """ If True, we are looking for the `start` title to start reading from """
-    end_reached = False
     with open(f"{config.path}/{titles_filename}", encoding="utf-8") as f:
         it = iter(f)
         line = next(it, None)
         next_line = next(it, None)
         while True:
-            title = line.strip() # Strip trailing '\n'
-                                 # TODO: Can title begins or ends with whitespaces? (https://docs.python.org/3/library/string.html#string.whitespace)
+            # Strip trailing '\n'
+            # A valid title DOES NOT contain leading or trailing whitespaces
+            # https://www.mediawiki.org/wiki/Manual:Page_title
+            title = line.strip()
 
             if next_line is None:
                 # TODO: Use global variable instead of hardcoding


### PR DESCRIPTION
Other things to do:

- Use global variable instead of hardcoding `"--END--"`
- `"--END--"` is a valid title, change it to something invalid