### PR TITLE
Replace CDN panic with warning.

### DIFF
--- a/wikiteam3/dumpgenerator/dump/image/image.py
+++ b/wikiteam3/dumpgenerator/dump/image/image.py
@@ -34,9 +34,12 @@ WBN_LATEST = 2
 WBM_BEST = 3
 
 
-def check_response(r: requests.Response) -> None:
+def check_response(r: requests.Response, bypass_cdn_image_compression: bool = False) -> None:
     if r.headers.get("cf-polished", ""):
-        raise RuntimeError("Found cf-polished header in response, use --bypass-cdn-image-compression to bypass it")
+        if bypass_cdn_image_compression:
+            raise RuntimeError("cf-polished header detected despite --bypass-cdn-image-compression. CDN bypass failed.")
+        else:
+            print("cf-polished header detected. Image may be compressed by CDN. Use --bypass-cdn-image-compression to attempt bypass.")
 
 class Image:
 
@@ -264,7 +267,7 @@ class Image:
                         r = session.get(url=url, params=modify_params(), headers=_headers, allow_redirects=True, stream=True)
                         r._content = r.raw.read()
 
-                    check_response(r)
+                    check_response(r, other.bypass_cdn_image_compression)
 
                     # a trick to get original file (fandom)
                     ori_url = url
@@ -278,7 +281,7 @@ class Image:
                         ori_url = url + "&format=original"
                         Delay(config=config)
                         r = session.get(url=ori_url, params=modify_params(), headers=modify_headers(), allow_redirects=True)
-                        check_response(r)
+                        check_response(r, other.bypass_cdn_image_compression)
 
                     # Try to fix a broken HTTP to HTTPS redirect
                     original_url_redirected: bool = r.url in (url, ori_url)
@@ -291,7 +294,7 @@ class Image:
                             url = "https://" + url_raw.split("://")[1]
                             # print 'Maybe a broken http to https redirect, trying ', url
                             r = session.get(url=url, params=modify_params(), headers=modify_headers(), allow_redirects=True)
-                            check_response(r)
+                            check_response(r, other.bypass_cdn_image_compression)
 
                 if r.status_code == 200:
                     try:


### PR DESCRIPTION
Hello! I've just stumbled upon this project while looking for a solution to dump a few wikis to my local drive. I've tried to dump one, using a command like
```sh
wikiteam3dumpgenerator --api https://whiteknuckle.miraheze.org/w/api.php --xml --images
```
Suddenly, I've encountered an error at the end of an export process
```
->  Downloaded 2850 pages

    Module:Infobox/doc, 2 edits
    Module:Key, 1 edit
    Module:Mbox, 1 edit
    Module:Mbox/data, 1 edit
    Module:Mbox/data/doc, 1 edit
    Module:Mbox/doc, 1 edit
    Module:Namespace detect, 1 edit
    Module:Namespace detect/config, 1 edit
    Module:Namespace detect/config/doc, 1 edit
    Module:Namespace detect/data, 1 edit
           
->  Downloaded 2860 pages

    Module:Namespace detect/data/doc, 1 edit
    Module:Namespace detect/doc, 1 edit
    Module:Navbox, 2 edits
    Module:Navbox/doc, 1 edit
    Module:Quote, 1 edit
    Module:Quote/doc, 1 edit
    Module:RandomImage, 1 edit
XML dump saved at... whiteknuckle.miraheze.org_w-20251229-history.xml
)Retrieving image filenames
Using API to retrieve image names...
    Found 1675 images                                            so far...
Sorting image filenames (1675 images)...
Done
Image metadata (images.txt) saved at: whiteknuckle.miraheze.org_w-20251229-images.txt
Estimated size of all images (images.txt): 1241180249 bytes (1.16 GiB)
--assert_max_images: None, passed
--assert_max_images_bytes: None, passed
Retrieving images...
Creating "whiteknuckle.miraheze.org_w-20251229-wikidump/images" directory
Creating "whiteknuckle.miraheze.org_w-20251229-wikidump/images_mismatch" directory
Traceback (most recent call last):g                                       
  File "/Users/vladimish/3rdparty/wikiteam3/.env/bin/wikiteam3dumpgenerator", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/vladimish/3rdparty/wikiteam3/.env/lib/python3.14/site-packages/wikiteam3/dumpgenerator/__init__.py", line 4, in main
    DumpGenerator()
    ~~~~~~~~~~~~~^^
  File "/Users/vladimish/3rdparty/wikiteam3/.env/lib/python3.14/site-packages/wikiteam3/dumpgenerator/dump/generator.py", line 86, in __init__
    DumpGenerator.createNewDump(config=config, other=other)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/vladimish/3rdparty/wikiteam3/.env/lib/python3.14/site-packages/wikiteam3/dumpgenerator/dump/generator.py", line 119, in createNewDump
    Image.generate_image_dump(
    ~~~~~~~~~~~~~~~~~~~~~~~~~^
        config=config, other=other, images=images, session=other.session
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/vladimish/3rdparty/wikiteam3/.env/lib/python3.14/site-packages/wikiteam3/dumpgenerator/dump/image/image.py", line 267, in generate_image_dump
    check_response(r)
    ~~~~~~~~~~~~~~^^^
  File "/Users/vladimish/3rdparty/wikiteam3/.env/lib/python3.14/site-packages/wikiteam3/dumpgenerator/dump/image/image.py", line 39, in check_response
    raise RuntimeError("Found cf-polished header in response, use --bypass-cdn-image-compression to bypass it")
RuntimeError: Found cf-polished header in response, use --bypass-cdn-image-compression to bypass it
```

following the advice in the logs to use --bypass-cdn-image-compression, I've re-run the dumper with a command like that
```
wikiteam3dumpgenerator --api https://whiteknuckle.miraheze.org/w/api.php --xml --images --bypass-cdn-image-compression
```
but unfortunately, result was the same. Apparently setting `_wiki_t` param does not prevent cf caching on some configurations, or I have some other network issues.
Either way, the original discussion under [bypass-cdn-image-compression flag PR](https://github.com/mediawiki-client-tools/mediawiki-dump-generator/pull/163) indicates, that showing a warning here would've been more preferable. Fully agree here, I doubt that most users would mind having CDN compression on the images and only if they want to bypass it - they should use the flag.
